### PR TITLE
Add support for aarch64 architecture in get_cpu_info

### DIFF
--- a/mdd.py
+++ b/mdd.py
@@ -301,28 +301,18 @@ def get_cpu_info():
         cpu_model += cpu_model2
 
     if not cpu_model:
-        # Fallback in case we did not get info from inxi
+        # Fallback to lscpu in case we did not get info from inxi
         try:
-            if platform.machine() == "aarch64":
-                cpu_model = (
-                    [
-                        line
-                        for line in get_command_output("cat /proc/cpuinfo").split("\n")
-                        if "Model" in line
-                    ][0]
-                    .split(":")[1]
-                    .strip()
-                )
-            else:
-                cpu_model = (
-                    [
-                        line
-                        for line in get_command_output("cat /proc/cpuinfo").split("\n")
-                        if "model name" in line
-                    ][0]
-                    .split(":")[1]
-                    .strip()
-                )
+            lines = [
+                line
+                for line in get_command_output("lscpu").split("\n")
+                if "Model name" in line
+            ]
+
+            cpu_model = lines[0].split(":")[1].strip()
+            if len(lines) > 1:
+                cpu_model += "/" + lines[1].split(":")[1].strip()
+
         except IndexError as e:
             pass
 


### PR DESCRIPTION
This PR updates the get_cpu_info function to handle the aarch64 architecture by checking for the appropriate CPU model identifier. It sets the default CPU model to "unknown" and adds error handling for missing model information. This ensures accurate data retrieval across different CPU architectures.

It also updates the get_system_info function to use values from `/proc/device-tree/compatible` 