### PR TITLE
fix: send error messages to /dev/null for dmi cat cmds

### DIFF
--- a/mdd.py
+++ b/mdd.py
@@ -233,7 +233,7 @@ def get_system_info():
     logging.info("...get system info")
 
     def get_dmi(file_name: str):
-        return get_command_output("cat /sys/devices/virtual/dmi/id/" + file_name)
+        return get_command_output("cat /sys/devices/virtual/dmi/id/" + file_name + " 2>/dev/null")
 
     return {
         "kernel": platform.release(),


### PR DESCRIPTION
On ARM devices dmi doesn't exist. We can silent the error output by sending them to `/dev/null`. See also #1 and https://github.com/manjaro/mdd/pull/2