### PR TITLE
feat: fallback to xrandr

### DIFF
--- a/mdd.py
+++ b/mdd.py
@@ -443,14 +443,20 @@ def get_audio_info():
     pulseaudio_active = False
     found_pipewire = False
 
-    if is_installed("pulseaudio") and shutil.which("pactl"):
+    sudo = ""
+    if os.geteuid() == 0:
+        user = get_command_output("last -n1").split("\n")[0].split(" ")[0]
+        user_id = get_command_output("sudo -u " + user + " id -u")
+        sudo = "sudo -u " + user + " XDG_RUNTIME_DIR=/run/user/" + user_id + " "
+
+    if is_installed("pulseaudio"):
         pulse_info = {
             "name": "PulseAudio",
             "active": False,
         }
 
         # pactl is a dependency of pulseaudio
-        pulse_out = get_command_output("LANG=C pactl info").split("\n")
+        pulse_out = get_command_output(sudo + "LANG=C pactl info").split("\n")
         for line in pulse_out:
             if line.startswith("Server Name"):
                 name = line.split(" ", 2)[-1].lower()
@@ -474,7 +480,7 @@ def get_audio_info():
 
     if not found_pipewire and is_installed("pipewire"):
         # Check if PipeWire is active (PulseAudio might not be installed)
-        pipew_out = get_command_output("LANG=C pw-cli info 0")
+        pipew_out = get_command_output(sudo + "LANG=C pw-cli info 0")
         info["servers"].append(
             {
                 "name": "PipeWire",

--- a/mdd.py
+++ b/mdd.py
@@ -450,7 +450,7 @@ def get_audio_info():
         }
 
         # pactl is a dependency of pulseaudio
-        pulse_out = get_command_output("pactl info").split("\n")
+        pulse_out = get_command_output("LANG=C pactl info").split("\n")
         for line in pulse_out:
             if line.startswith("Server Name"):
                 name = line.split(" ", 2)[-1].lower()
@@ -474,7 +474,7 @@ def get_audio_info():
 
     if not found_pipewire and is_installed("pipewire"):
         # Check if PipeWire is active (PulseAudio might not be installed)
-        pipew_out = get_command_output("pw-cli info 0")
+        pipew_out = get_command_output("LANG=C pw-cli info 0")
         info["servers"].append(
             {
                 "name": "PipeWire",


### PR DESCRIPTION
In some cases inxi can't find basic graphics data. In this case let's fallback to xrandr to complement the data.

In the future we might additionally look into a fallback to wayland-info. But as a first step the xrandr fallback is sufficient as it is also available on Wayland via Xwayland.