### PR TITLE
Grep pacman log with -a flag 

### DIFF
--- a/mdd.py
+++ b/mdd.py
@@ -680,9 +680,7 @@ def get_package_info():
         "branch": get_command_output("pacman-mirrors -G", "unknown"),
         "pkgs": int(get_command_output("pacman -Q | wc -l")),
         "foreign_pkgs": int(get_command_output("pacman -Qm | wc -l")),
-        "pkgs_update_pending": int(
-            get_command_output("pacman -Qu | wc -l")
-        ),
+        "pkgs_update_pending": int(get_command_output("pacman -Qu | wc -l")),
         "flatpaks": flatpaks,
         "pacman_mirrors": get_pacman_mirrors_info(),
     }

--- a/mdd.py
+++ b/mdd.py
@@ -663,7 +663,7 @@ def get_package_info():
 
     try:
         output = get_command_output(
-            'grep "\\[ALPM\\] upgraded" /var/log/pacman.log | tail -1'
+            'grep -a "\\[ALPM\\] upgraded" /var/log/pacman.log | tail -1'
         )
         update_time = date_parser.parse(output.split(" ")[0].strip("[]")).isoformat()
     except Exception as e:


### PR DESCRIPTION
This ensures the data is interpreted as text. Otherwise the result of the call might be wrong.

Closes #13